### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Munch
+# Munch
 A minimalistic, easy to use Rss reader application.
 
 <a href="https://play.google.com/store/apps/details?id=com.crazyhitty.chdev.ks.munch">
@@ -7,17 +7,17 @@ A minimalistic, easy to use Rss reader application.
 </a>
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Munch-brightgreen.svg?style=flat)](http://android-arsenal.com/details/3/2955)
 
-#What is Munch ?
+# What is Munch ?
 Munch is an android app which enable the users to manage their Rss feeds. User can add new sources, manage them and view the article associated with the feeds.
 
-#Permissions:
+# Permissions:
 * Internet
 * Access Network State
 * Read External Storage
 
 These permissions are used to grab the data from the web and to know if user’s internet is available or not so that he can be notified regarding that matter. The Read External Storage permissions is used to retrieve the opml files from either SD card or internal storage. Also, this app will never snoop on your personal information.
 
-#Application features:
+# Application features:
 * Load Rss feeds quickly
 * Add Rss Sources
 * Manage Rss Sources
@@ -25,10 +25,10 @@ These permissions are used to grab the data from the web and to know if user’s
 * Customizable settings
 * Ad free
 
-#How does Munch work ?
+# How does Munch work ?
 Munch uses jsoup xml parser to parse rss feeds and also load the web articles associated with those feeds. It also uses glide to lazy load article images(if available).
 
-#Screenshots
+# Screenshots
 ![](https://lh3.googleusercontent.com/_nFUASUq-EEayxKAR5J2Pne94Fi_napfkaF8Ov1s7rPZuBH9kQBQtbK9L1F2FQa7YUg=h900-rw)
 ![](https://lh3.googleusercontent.com/625tiEodzuBVr5R_g8sVff8m-Z74EH1LdzRa6XufT94qcUCw13HaVdkUSIxbDWQ1hA=h900-rw)
 ![](https://lh3.googleusercontent.com/4GGI6N2Zdtg1-Fd1RuhEbJ3PWUEeR-ioyOt7XdUrelgAD6gJqnnaRot8PW0I-s39Cg=h900-rw)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
